### PR TITLE
Add typing_action decorator test

### DIFF
--- a/bot/utils/decorators.py
+++ b/bot/utils/decorators.py
@@ -85,14 +85,17 @@ def error_handler(func: Callable) -> Callable:
     return wrapper
 
 
+from telegram.constants import ChatAction
+
+
 def typing_action(func: Callable) -> Callable:
     """Decorator to show typing action"""
     @functools.wraps(func)
     async def wrapper(update: Update, context: ContextTypes.DEFAULT_TYPE, *args, **kwargs):
-        if update.message:
-            await update.message.chat.send_action("typing")
+        if getattr(update, "effective_chat", None):
+            await update.effective_chat.send_action(ChatAction.TYPING)
         return await func(update, context, *args, **kwargs)
-    
+
     return wrapper
 
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,0 +1,28 @@
+import types
+from unittest.mock import AsyncMock
+
+import pytest
+from telegram.constants import ChatAction
+
+from bot.utils.decorators import typing_action
+
+
+@pytest.mark.asyncio
+async def test_typing_action_triggers_send_action():
+    mock_chat = types.SimpleNamespace(send_action=AsyncMock())
+    update = types.SimpleNamespace(effective_chat=mock_chat)
+    context = object()
+
+    called = False
+
+    @typing_action
+    async def sample(update, context):
+        nonlocal called
+        called = True
+        return "result"
+
+    result = await sample(update, context)
+
+    assert called is True
+    mock_chat.send_action.assert_awaited_once_with(ChatAction.TYPING)
+    assert result == "result"


### PR DESCRIPTION
## Summary
- update `typing_action` decorator to use `effective_chat.send_action` with `ChatAction.TYPING`
- add unit test for the decorator using pytest and pytest-asyncio

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'telegram')*

------
https://chatgpt.com/codex/tasks/task_e_684b283a3b4c832491e60390813ac4a7