### PR TITLE
Clean up admin handler imports

### DIFF
--- a/bot/handlers/admin.py
+++ b/bot/handlers/admin.py
@@ -3,8 +3,6 @@ Admin-specific handlers and functionality
 """
 import logging
 import asyncio
-from typing import List, Dict, Any
-from datetime import datetime, timezone, timedelta
 from datetime import datetime, timezone
 
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup


### PR DESCRIPTION
## Summary
- remove unused typing and timedelta imports in admin handler

## Testing
- `python - <<'PY'
from bot.handlers import setup_handlers
print('handlers import ok')
PY`
- `python - <<'PY'
from bot.services import parser
print('parser import ok')
PY`
- `python - <<'PY'
from bot.utils import state
print('state import ok')
PY`
- `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics` *(fails: F824 `global _state` is unused)*
- `flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684b402a952c832487016122e1dce8ad